### PR TITLE
Fix calling class with service_ensure stopped

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,8 +42,11 @@ class snap (
     provider => 'puppet_gem',
   }
 
-  -> package { 'core':
-    ensure   => $core_snap_ensure,
-    provider => 'snap',
+  if $service_ensure == 'running' {
+    package { 'core':
+      ensure   => $core_snap_ensure,
+      provider => 'snap',
+      require  => Package['net_http_unix'],
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class snap (
     package { 'core':
       ensure   => $core_snap_ensure,
       provider => 'snap',
-      require  => Package['net_http_unix'],
+      require  => [Package['net_http_unix'], Service['snapd']],
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'snap' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with snapd running" do
       let(:facts) do
         facts
       end
@@ -17,6 +17,23 @@ describe 'snap' do
       it { is_expected.to contain_service('snapd').with_ensure('running').with_enable(true).that_requires('Package[snapd]') }
       it { is_expected.to contain_package('net_http_unix').with_ensure('installed').with_provider('puppet_gem').that_requires('Service[snapd]') }
       it { is_expected.to contain_package('core').with_ensure('installed').with_provider('snap').that_requires(%w[Service[snapd] Package[net_http_unix]]) }
+    end
+
+    context "on #{os} with snapd stopped" do
+      let(:facts) do
+        facts
+      end
+      
+      let(:params) do
+        { 'service_ensure' => 'stopped' }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_package('snapd').with_ensure('installed') }
+      it { is_expected.to contain_service('snapd').with_ensure('stopped').with_enable(true).that_requires('Package[snapd]') }
+      it { is_expected.to contain_package('net_http_unix').with_ensure('installed').with_provider('puppet_gem').that_requires('Service[snapd]') }
+      it { is_expected.not_to contain_package('core').with_provider('snap') }
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,7 +23,7 @@ describe 'snap' do
       let(:facts) do
         facts
       end
-      
+
       let(:params) do
         { 'service_ensure' => 'stopped' }
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Using the `snap` provider inside the `snap` class prevents us from using the class to stop `snapd` itself. Since this seems to be sort of supported based on params, this simple conditional fixes the problem.

#### This Pull Request (PR) fixes the following issues
n/a (none open on this repo)