### PR TITLE
Make provider holdable

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,47 +12,8 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "9"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "9"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "9"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "9"
-      ]
-    },
-    {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "40"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "11",
-        "12"
-      ]
-    },
-    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
-        "22.04",
         "24.04"
       ]
     }

--- a/spec/acceptance/01_snapd_spec.rb
+++ b/spec/acceptance/01_snapd_spec.rb
@@ -110,11 +110,11 @@ describe 'snapd class' do
 
       it_behaves_like 'an idempotent resource'
 
-      describe command('snap list --unicode=never --color=never') do
+      describe command('snap info --unicode=never --color=never --abs-time hello-world') do
         its(:stdout) do
-          is_expected.to match(%r{hello-world})
-          is_expected.to match(%r{beta})
-          is_expected.to match(%r{held})
+          is_expected.to match(%r{name:\s+hello-world})
+          is_expected.to match(%r{tracking:\s+latest/beta})
+          is_expected.to match(%r{hold:\s+forever})
         end
       end
     end
@@ -132,11 +132,11 @@ describe 'snapd class' do
 
       it_behaves_like 'an idempotent resource'
 
-      describe command('snap list --unicode=never --color=never') do
+      describe command('snap info --unicode=never --color=never --abs-time hello-world') do
         its(:stdout) do
-          is_expected.to match(%r{hello-world})
-          is_expected.to match(%r{candidate})
-          is_expected.to match(%r{held})
+          is_expected.to match(%r{name:\s+hello-world})
+          is_expected.to match(%r{tracking:\s+latest/candidate})
+          is_expected.to match(%r{hold:\s+forever})
         end
       end
     end
@@ -155,11 +155,11 @@ describe 'snapd class' do
 
       it_behaves_like 'an idempotent resource'
 
-      describe command('snap list --unicode=never --color=never') do
+      describe command('snap info --unicode=never --color=never --abs-time hello-world') do
         its(:stdout) do
-          is_expected.to match(%r{hello-world})
-          is_expected.to match(%r{candidate})
-          is_expected.to match(%r{held})
+          is_expected.to match(%r{name:\s+hello-world})
+          is_expected.to match(%r{tracking:\s+latest/candidate})
+          is_expected.to match(%r{hold:\s+2025-10-10T03:00:00})
         end
       end
     end
@@ -176,11 +176,11 @@ describe 'snapd class' do
 
       it_behaves_like 'an idempotent resource'
 
-      describe command('snap list --unicode=never --color=never') do
+      describe command('snap info --unicode=never --color=never --abs-time hello-world') do
         its(:stdout) do
-          is_expected.to match(%r{hello-world})
-          is_expected.to match(%r{candidate})
-          is_expected.not_to match(%r{held})
+          is_expected.to match(%r{name:\s+hello-world})
+          is_expected.to match(%r{tracking:\s+latest/candidate})
+          is_expected.not_to match(%r{hold:.*})
         end
       end
     end

--- a/spec/acceptance/01_snapd_spec.rb
+++ b/spec/acceptance/01_snapd_spec.rb
@@ -96,35 +96,123 @@ describe 'snapd class' do
         end
       end
     end
-  end
 
-  describe 'purges the package' do
-    let(:manifest) do
-      <<-PUPPET
+    describe 'holds the package (prevents refresh)' do
+      let(:manifest) do
+        <<-PUPPET
+          package { 'hello-world':
+            ensure    => 'latest/beta',
+            mark      => 'hold',
+            provider  => 'snap',
+          }
+        PUPPET
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('snap list --unicode=never --color=never') do
+        its(:stdout) do
+          is_expected.to match(%r{hello-world})
+          is_expected.to match(%r{beta})
+          is_expected.to match(%r{held})
+        end
+      end
+    end
+
+    describe 'can change channel while held' do
+      let(:manifest) do
+        <<-PUPPET
+          package { 'hello-world':
+            ensure    => 'latest/candidate',
+            mark      => 'hold',
+            provider  => 'snap',
+          }
+        PUPPET
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('snap list --unicode=never --color=never') do
+        its(:stdout) do
+          is_expected.to match(%r{hello-world})
+          is_expected.to match(%r{candidate})
+          is_expected.to match(%r{held})
+        end
+      end
+    end
+
+    describe 'hold until specified date' do
+      let(:manifest) do
+        <<-PUPPET
+          package { 'hello-world':
+            ensure          => 'latest/candidate',
+            mark            => 'hold',
+            install_options => 'hold_time=2025-10-10', # Non RFC3339, it should be parsed correctly
+            provider        => 'snap',
+          }
+        PUPPET
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('snap list --unicode=never --color=never') do
+        its(:stdout) do
+          is_expected.to match(%r{hello-world})
+          is_expected.to match(%r{candidate})
+          is_expected.to match(%r{held})
+        end
+      end
+    end
+
+    describe 'unholds the package' do
+      let(:manifest) do
+        <<-PUPPET
+          package { 'hello-world':
+            ensure    => 'latest/candidate',
+            provider  => 'snap',
+          }
+        PUPPET
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('snap list --unicode=never --color=never') do
+        its(:stdout) do
+          is_expected.to match(%r{hello-world})
+          is_expected.to match(%r{candidate})
+          is_expected.not_to match(%r{held})
+        end
+      end
+    end
+
+    describe 'purges the package' do
+      let(:manifest) do
+        <<-PUPPET
           package { 'hello-world':
             ensure   => purged,
             provider => snap,
           }
-      PUPPET
+        PUPPET
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('snap list --unicode=never --color=never') do
+        its(:stdout) { is_expected.not_to match(%r{hello-world}) }
+      end
     end
 
-    it_behaves_like 'an idempotent resource'
-
-    describe command('snap list --unicode=never --color=never') do
-      its(:stdout) { is_expected.not_to match(%r{hello-world}) }
-    end
-  end
-
-  # rubocop:disable RSpec/EmptyExampleGroup
-  describe 'Raises error when ensure => latest' do
-    manifest = <<-PUPPET
+    # rubocop:disable RSpec/EmptyExampleGroup
+    describe 'Raises error when ensure => latest' do
+      manifest = <<-PUPPET
           package { 'hello-world':
             ensure   => latest,
             provider => snap,
           }
-    PUPPET
+      PUPPET
 
-    apply_manifest(manifest, expect_failures: true)
+      apply_manifest(manifest, expect_failures: true)
+    end
+    # rubocop:enable RSpec/EmptyExampleGroup
   end
-  # rubocop:enable RSpec/EmptyExampleGroup
 end

--- a/spec/unit/puppet/provider/package/snap_spec.rb
+++ b/spec/unit/puppet/provider/package/snap_spec.rb
@@ -28,6 +28,7 @@ describe Puppet::Type.type(:package).provider(:snap) do
     it { is_expected.to be_uninstallable }
     it { is_expected.to be_purgeable }
     it { is_expected.to be_upgradeable }
+    it { is_expected.to be_holdable }
   end
 
   context 'should respond to' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Makes provider holdable via `mark` property. If a package is held it prevents refreshes for the specified time defined by the `hold_time` install option.

`hold_time` can be:
- forever
- time format defined by RFC3339

It's not necessary to define the time in full, e.g `2024-10-10` will work, as well as `2024-10-10T23:59`

Example snippet

```puppet
package { 'hello-world:
   ensure   => 'latest/stable',
   mark     => 'hold',
   provider => 'snap',
}
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
